### PR TITLE
Fix incorrect namespace lowercase letter

### DIFF
--- a/Assets/DeveloperConsole/Core/Commands.cs
+++ b/Assets/DeveloperConsole/Core/Commands.cs
@@ -359,7 +359,7 @@ namespace Console
             public override ConsoleOutput Logic()
             {
                 base.Logic();
-                System.media.SystemSounds.Beep.Play();
+                System.Media.SystemSounds.Beep.Play();
                 return new ConsoleOutput("Beeping", ConsoleOutput.OutputType.Log);
             }
         }


### PR DESCRIPTION
**The word "media" of `System.Media` namespace should be uppercase on the first letter.**

If a project is using `.NET 4.x` API compatibility level, it will cause `CS0234: namespace name 'media' does not exist` error.