### PR TITLE
Fix generic methods AOT (IL2CPP) code exception

### DIFF
--- a/Assets/DeveloperConsole/Core/Command.cs
+++ b/Assets/DeveloperConsole/Core/Command.cs
@@ -59,6 +59,11 @@ namespace Console {
         {
             return new ConsoleOutput("", ConsoleOutput.OutputType.Log);
         }
+        
+        public virtual void UsedOnlyForAOTCodeGeneration() 
+        {
+            throw new InvalidOperationException("This method is used for AOT code generation only. Do not call it at runtime.");
+        }
 
         public string GetDescription()
         {

--- a/Assets/DeveloperConsole/Core/Commands.cs
+++ b/Assets/DeveloperConsole/Core/Commands.cs
@@ -196,12 +196,6 @@ namespace Console
         {
             [CommandParameter("command")]
             public string queryIdentity;
-            public override void UsedOnlyForAOTCodeGeneration()
-            {
-                base.UsedOnlyForAOTCodeGeneration();
-                new CommandParameter<string>(null, null);
-                DeveloperConsole.ParamQuery<string>(null);
-            }
             public HelpCommand()
             {
 
@@ -404,12 +398,6 @@ namespace Console
         {
             [CommandParameter("string")]
             public string echoText;
-            public override void UsedOnlyForAOTCodeGeneration()
-            {
-                base.UsedOnlyForAOTCodeGeneration();
-                new CommandParameter<string>(null, null);
-                DeveloperConsole.ParamQuery<string>(null);
-            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -456,12 +444,6 @@ namespace Console
         {
             [CommandParameter("level")]
             public string targetLevel;
-            public override void UsedOnlyForAOTCodeGeneration()
-            {
-                base.UsedOnlyForAOTCodeGeneration();
-                new CommandParameter<string>(null, null);
-                DeveloperConsole.ParamQuery<string>(null);
-            }
 
             public override ConsoleOutput Logic()
             {
@@ -485,12 +467,6 @@ namespace Console
         {
             [CommandParameter("adress")]
             public string targetLevel;
-            public override void UsedOnlyForAOTCodeGeneration()
-            {
-                base.UsedOnlyForAOTCodeGeneration();
-                new CommandParameter<string>(null, null);
-                DeveloperConsole.ParamQuery<string>(null);
-            }
 
             public override ConsoleOutput Logic()
             {

--- a/Assets/DeveloperConsole/Core/Commands.cs
+++ b/Assets/DeveloperConsole/Core/Commands.cs
@@ -253,9 +253,7 @@ namespace Console
             public override void UsedOnlyForAOTCodeGeneration()
             {
                 base.UsedOnlyForAOTCodeGeneration();
-                new CommandParameter<Transform>(null, null);
                 new CommandParameter<Vector3>(null, null);
-                DeveloperConsole.ParamQuery<Transform>(null);
                 DeveloperConsole.ParamQuery<Vector3>(null);
             }
             public Move()
@@ -283,9 +281,7 @@ namespace Console
             public override void UsedOnlyForAOTCodeGeneration()
             {
                 base.UsedOnlyForAOTCodeGeneration();
-                new CommandParameter<Transform>(null, null);
                 new CommandParameter<Quaternion>(null, null);
-                DeveloperConsole.ParamQuery<Transform>(null);
                 DeveloperConsole.ParamQuery<Quaternion>(null);
             }
             public Rotate()
@@ -1148,12 +1144,7 @@ namespace Console
         {
             [CommandParameter("CultureInfo")]
             public System.Globalization.CultureInfo value;
-            public override void UsedOnlyForAOTCodeGeneration()
-            {
-                base.UsedOnlyForAOTCodeGeneration();
-                new CommandParameter<System.Globalization.CultureInfo>(null, null);
-                DeveloperConsole.ParamQuery<System.Globalization.CultureInfo>(null);
-            }
+
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -1189,9 +1180,7 @@ namespace Console
             public override void UsedOnlyForAOTCodeGeneration()
             {
                 base.UsedOnlyForAOTCodeGeneration();
-                new CommandParameter<Rigidbody>(null, null);
                 new CommandParameter<Vector3>(null, null);
-                DeveloperConsole.ParamQuery<Rigidbody>(null);
                 DeveloperConsole.ParamQuery<Vector3>(null);
             }
             public override ConsoleOutput Logic()
@@ -1216,9 +1205,7 @@ namespace Console
             public override void UsedOnlyForAOTCodeGeneration()
             {
                 base.UsedOnlyForAOTCodeGeneration();
-                new CommandParameter<Rigidbody>(null, null);
                 new CommandParameter<float>(null, null);
-                DeveloperConsole.ParamQuery<Rigidbody>(null);
                 DeveloperConsole.ParamQuery<float>(null);
             }
             public override ConsoleOutput Logic()
@@ -1243,9 +1230,7 @@ namespace Console
             public override void UsedOnlyForAOTCodeGeneration()
             {
                 base.UsedOnlyForAOTCodeGeneration();
-                new CommandParameter<Rigidbody>(null, null);
                 new CommandParameter<float>(null, null);
-                DeveloperConsole.ParamQuery<Rigidbody>(null);
                 DeveloperConsole.ParamQuery<float>(null);
             }
             public override ConsoleOutput Logic()
@@ -1268,9 +1253,7 @@ namespace Console
             public override void UsedOnlyForAOTCodeGeneration()
             {
                 base.UsedOnlyForAOTCodeGeneration();
-                new CommandParameter<Rigidbody>(null, null);
                 new CommandParameter<bool>(null, null);
-                DeveloperConsole.ParamQuery<Rigidbody>(null);
                 DeveloperConsole.ParamQuery<bool>(null);
             }
 
@@ -1296,9 +1279,7 @@ namespace Console
             public override void UsedOnlyForAOTCodeGeneration()
             {
                 base.UsedOnlyForAOTCodeGeneration();
-                new CommandParameter<Rigidbody>(null, null);
                 new CommandParameter<bool>(null, null);
-                DeveloperConsole.ParamQuery<Rigidbody>(null);
                 DeveloperConsole.ParamQuery<bool>(null);
             }
 

--- a/Assets/DeveloperConsole/Core/Commands.cs
+++ b/Assets/DeveloperConsole/Core/Commands.cs
@@ -1144,7 +1144,6 @@ namespace Console
         {
             [CommandParameter("CultureInfo")]
             public System.Globalization.CultureInfo value;
-
             public override ConsoleOutput Logic()
             {
                 base.Logic();

--- a/Assets/DeveloperConsole/Core/Commands.cs
+++ b/Assets/DeveloperConsole/Core/Commands.cs
@@ -200,6 +200,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<string>(null, null);
+                DeveloperConsole.ParamQuery<string>(null);
             }
             public HelpCommand()
             {
@@ -260,6 +261,8 @@ namespace Console
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<Transform>(null, null);
                 new CommandParameter<Vector3>(null, null);
+                DeveloperConsole.ParamQuery<Transform>(null);
+                DeveloperConsole.ParamQuery<Vector3>(null);
             }
             public Move()
             {
@@ -288,6 +291,8 @@ namespace Console
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<Transform>(null, null);
                 new CommandParameter<Quaternion>(null, null);
+                DeveloperConsole.ParamQuery<Transform>(null);
+                DeveloperConsole.ParamQuery<Quaternion>(null);
             }
             public Rotate()
             {
@@ -403,6 +408,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<string>(null, null);
+                DeveloperConsole.ParamQuery<string>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -421,6 +427,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<int>(null, null);
+                DeveloperConsole.ParamQuery<int>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -453,6 +460,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<string>(null, null);
+                DeveloperConsole.ParamQuery<string>(null);
             }
 
             public override ConsoleOutput Logic()
@@ -481,6 +489,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<string>(null, null);
+                DeveloperConsole.ParamQuery<string>(null);
             }
 
             public override ConsoleOutput Logic()
@@ -518,6 +527,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<float>(null, null);
+                DeveloperConsole.ParamQuery<float>(null);
             }
 
             public override ConsoleOutput Logic()
@@ -551,6 +561,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<float>(null, null);
+                DeveloperConsole.ParamQuery<float>(null);
             }
 
             public override ConsoleOutput Logic()
@@ -571,6 +582,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<float>(null, null);
+                DeveloperConsole.ParamQuery<float>(null);
             }
 
             public override ConsoleOutput Logic()
@@ -618,6 +630,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<Color>(null, null);
+                DeveloperConsole.ParamQuery<Color>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -641,6 +654,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<bool>(null, null);
+                DeveloperConsole.ParamQuery<bool>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -663,6 +677,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<float>(null, null);
+                DeveloperConsole.ParamQuery<float>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -685,6 +700,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<float>(null, null);
+                DeveloperConsole.ParamQuery<float>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -737,6 +753,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<Vector3>(null, null);
+                DeveloperConsole.ParamQuery<Vector3>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -756,6 +773,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<float>(null, null);
+                DeveloperConsole.ParamQuery<float>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -775,6 +793,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<float>(null, null);
+                DeveloperConsole.ParamQuery<float>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -794,6 +813,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<float>(null, null);
+                DeveloperConsole.ParamQuery<float>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -815,6 +835,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<float>(null, null);
+                DeveloperConsole.ParamQuery<float>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -835,6 +856,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<Vector3>(null, null);
+                DeveloperConsole.ParamQuery<Vector3>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -855,6 +877,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<int>(null, null);
+                DeveloperConsole.ParamQuery<int>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -875,6 +898,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<int>(null, null);
+                DeveloperConsole.ParamQuery<int>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -895,6 +919,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<bool>(null, null);
+                DeveloperConsole.ParamQuery<bool>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -915,6 +940,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<int>(null, null);
+                DeveloperConsole.ParamQuery<int>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -935,6 +961,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<bool>(null, null);
+                DeveloperConsole.ParamQuery<bool>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -978,6 +1005,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<float>(null, null);
+                DeveloperConsole.ParamQuery<float>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -997,6 +1025,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<int>(null, null);
+                DeveloperConsole.ParamQuery<int>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -1016,6 +1045,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<bool>(null, null);
+                DeveloperConsole.ParamQuery<bool>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -1035,6 +1065,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<int>(null, null);
+                DeveloperConsole.ParamQuery<int>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -1069,6 +1100,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<float>(null, null);
+                DeveloperConsole.ParamQuery<float>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -1103,6 +1135,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<bool>(null, null);
+                DeveloperConsole.ParamQuery<bool>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -1254,6 +1287,8 @@ namespace Console
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<Rigidbody>(null, null);
                 new CommandParameter<bool>(null, null);
+                DeveloperConsole.ParamQuery<Rigidbody>(null);
+                DeveloperConsole.ParamQuery<bool>(null);
             }
 
 
@@ -1280,6 +1315,8 @@ namespace Console
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<Rigidbody>(null, null);
                 new CommandParameter<bool>(null, null);
+                DeveloperConsole.ParamQuery<Rigidbody>(null);
+                DeveloperConsole.ParamQuery<bool>(null);
             }
 
 

--- a/Assets/DeveloperConsole/Core/Commands.cs
+++ b/Assets/DeveloperConsole/Core/Commands.cs
@@ -196,6 +196,11 @@ namespace Console
         {
             [CommandParameter("command")]
             public string queryIdentity;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<string>(null, null);
+            }
             public HelpCommand()
             {
 
@@ -250,6 +255,12 @@ namespace Console
             public Transform transform;
             [CommandParameter("position")]
             public Vector3 position;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<Transform>(null, null);
+                new CommandParameter<Vector3>(null, null);
+            }
             public Move()
             {
 
@@ -272,6 +283,12 @@ namespace Console
             public Transform transform;
             [CommandParameter("rotation")]
             public Quaternion rotation;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<Transform>(null, null);
+                new CommandParameter<Quaternion>(null, null);
+            }
             public Rotate()
             {
 
@@ -382,6 +399,11 @@ namespace Console
         {
             [CommandParameter("string")]
             public string echoText;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<string>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -395,6 +417,11 @@ namespace Console
         {
             [CommandParameter("maxFPS")]
             public int maxFPS;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<int>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -422,6 +449,11 @@ namespace Console
         {
             [CommandParameter("level")]
             public string targetLevel;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<string>(null, null);
+            }
 
             public override ConsoleOutput Logic()
             {
@@ -445,6 +477,11 @@ namespace Console
         {
             [CommandParameter("adress")]
             public string targetLevel;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<string>(null, null);
+            }
 
             public override ConsoleOutput Logic()
             {
@@ -477,6 +514,11 @@ namespace Console
         {
             [CommandParameter("float")]
             public float value;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<float>(null, null);
+            }
 
             public override ConsoleOutput Logic()
             {
@@ -505,6 +547,11 @@ namespace Console
         {
             [CommandParameter("float")]
             public float value;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<float>(null, null);
+            }
 
             public override ConsoleOutput Logic()
             {
@@ -520,6 +567,11 @@ namespace Console
         {
             [CommandParameter("float")]
             public float value;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<float>(null, null);
+            }
 
             public override ConsoleOutput Logic()
             {
@@ -562,6 +614,11 @@ namespace Console
 
             [CommandParameter("r,g,b")]
             public Color Color;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<Color>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -580,6 +637,11 @@ namespace Console
 
             [CommandParameter("bool")]
             public bool fog;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<bool>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -597,6 +659,11 @@ namespace Console
 
             [CommandParameter("float")]
             public float start;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<float>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -614,6 +681,11 @@ namespace Console
 
             [CommandParameter("float")]
             public float start;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<float>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -661,6 +733,11 @@ namespace Console
         {
             [CommandParameter("Vector3")]
             public Vector3 gravity;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<Vector3>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -675,6 +752,11 @@ namespace Console
         {
             [CommandParameter("float")]
             public float value;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<float>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -689,6 +771,11 @@ namespace Console
         {
             [CommandParameter("float")]
             public float value;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<float>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -703,6 +790,11 @@ namespace Console
         {
             [CommandParameter("float")]
             public float value;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<float>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -719,6 +811,11 @@ namespace Console
         {
             [CommandParameter("float")]
             public float value;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<float>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -734,6 +831,11 @@ namespace Console
         {
             [CommandParameter("Vector3")]
             public Vector3 value;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<Vector3>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -749,6 +851,11 @@ namespace Console
         {
             [CommandParameter("ShadowQuality")]
             public int value;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<int>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -764,6 +871,11 @@ namespace Console
         {
             [CommandParameter("resolution")]
             public int value;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<int>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -779,6 +891,11 @@ namespace Console
         {
             [CommandParameter("bool")]
             public bool value;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<bool>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -794,6 +911,11 @@ namespace Console
         {
             [CommandParameter("int")]
             public int value;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<int>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -809,6 +931,11 @@ namespace Console
         {
             [CommandParameter("bool")]
             public bool value;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<bool>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -847,6 +974,11 @@ namespace Console
         {
             [CommandParameter("float")]
             public float value;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<float>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -861,6 +993,11 @@ namespace Console
         {
             [CommandParameter("int")]
             public int value;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<int>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -875,6 +1012,11 @@ namespace Console
         {
             [CommandParameter("bool")]
             public bool value;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<bool>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -889,6 +1031,11 @@ namespace Console
         {
             [CommandParameter("int")]
             public int value;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<int>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -918,6 +1065,11 @@ namespace Console
         {
             [CommandParameter("float")]
             public float value;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<float>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -947,6 +1099,11 @@ namespace Console
         {
             [CommandParameter("bool")]
             public bool value;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<bool>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -982,6 +1139,11 @@ namespace Console
         {
             [CommandParameter("CultureInfo")]
             public System.Globalization.CultureInfo value;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<System.Globalization.CultureInfo>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -1014,6 +1176,12 @@ namespace Console
 
             [CommandParameter("Vector3")]
             public Vector3 force;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<Rigidbody>(null, null);
+                new CommandParameter<Vector3>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -1033,6 +1201,12 @@ namespace Console
 
             [CommandParameter("Vector3")]
             public float mass;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<Rigidbody>(null, null);
+                new CommandParameter<float>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -1052,6 +1226,12 @@ namespace Console
 
             [CommandParameter("Vector3")]
             public float drag;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<Rigidbody>(null, null);
+                new CommandParameter<float>(null, null);
+            }
             public override ConsoleOutput Logic()
             {
                 base.Logic();
@@ -1069,6 +1249,12 @@ namespace Console
             public Rigidbody Rigidbody;
             [CommandParameter("bool")]
             public bool value;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<Rigidbody>(null, null);
+                new CommandParameter<bool>(null, null);
+            }
 
 
             public override ConsoleOutput Logic()
@@ -1089,6 +1275,12 @@ namespace Console
             public Rigidbody Rigidbody;
             [CommandParameter("bool")]
             public bool value;
+            public override void UsedOnlyForAOTCodeGeneration()
+            {
+                base.UsedOnlyForAOTCodeGeneration();
+                new CommandParameter<Rigidbody>(null, null);
+                new CommandParameter<bool>(null, null);
+            }
 
 
             public override ConsoleOutput Logic()

--- a/Assets/DeveloperConsole/Core/Commands.cs
+++ b/Assets/DeveloperConsole/Core/Commands.cs
@@ -1152,6 +1152,7 @@ namespace Console
             {
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<System.Globalization.CultureInfo>(null, null);
+                DeveloperConsole.ParamQuery<System.Globalization.CultureInfo>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -1190,6 +1191,8 @@ namespace Console
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<Rigidbody>(null, null);
                 new CommandParameter<Vector3>(null, null);
+                DeveloperConsole.ParamQuery<Rigidbody>(null);
+                DeveloperConsole.ParamQuery<Vector3>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -1215,6 +1218,8 @@ namespace Console
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<Rigidbody>(null, null);
                 new CommandParameter<float>(null, null);
+                DeveloperConsole.ParamQuery<Rigidbody>(null);
+                DeveloperConsole.ParamQuery<float>(null);
             }
             public override ConsoleOutput Logic()
             {
@@ -1240,6 +1245,8 @@ namespace Console
                 base.UsedOnlyForAOTCodeGeneration();
                 new CommandParameter<Rigidbody>(null, null);
                 new CommandParameter<float>(null, null);
+                DeveloperConsole.ParamQuery<Rigidbody>(null);
+                DeveloperConsole.ParamQuery<float>(null);
             }
             public override ConsoleOutput Logic()
             {


### PR DESCRIPTION
Close #9 

When building with IL2CPP, it uses an AOT compiler, but there is some limitation with the compiler. For instance, it cannot use generic methods with value types that are created during runtime as the compiler didn't generate the corresponding code for it.

As the source code has used `MakeGenericType` and `MakeGenericMethod` with value types that are not compatible with AOT compile, it will throw an `ExecutionEngineException`.

**The current solution is to hint the compiler to generate the corresponding code by explicitly calling the generic methods or creating an instance of it. Though it's not the best solution but rather a workaround.**

Unity has planned to implement the support of `MakeGenericType` with value types, but we don't know when it will be ready. They say they are working on it at the moment. (See Reference Below)

Reference:
[Unity - Manual:  Scripting restrictions](https://docs.unity3d.com/Manual/ScriptingRestrictions.html)
[IL2CPP Type.MakeGenericType work around - Unity Forum](https://forum.unity.com/threads/il2cpp-type-makegenerictype-work-around.311926/)
[Invoke generic method via reflection in C# IL2CPP on iOS - Stack Overflow](https://stackoverflow.com/questions/56183606/invoke-generic-method-via-reflection-in-c-sharp-il2cpp-on-ios)