### PR TITLE
Fix GetCustomAttributes Error in IL2CPP build

### DIFF
--- a/Assets/DeveloperConsole/Core/ConsoleUtility.cs
+++ b/Assets/DeveloperConsole/Core/ConsoleUtility.cs
@@ -164,7 +164,7 @@ namespace Console
                 foreach (System.Type type in assembly.GetTypes())
                 {
 
-                    if (type.GetCustomAttributes(typeof(ConsoleCommandAttribute), false).Length > 0 && type.BaseType == typeof(Command))
+                    if (type.IsDefined(typeof(ConsoleCommandAttribute), false) && type.BaseType == typeof(Command))
                     {
                         Command instance = (Command)Activator.CreateInstance(type);
                         yield return instance;


### PR DESCRIPTION
Unity is having a bug when using `System.Type.GetCustomAttributes` in IL2CPP build. 
Though Unity says the bug had been fixed, I can still reproduce it in Unity 2019.3.10f1.

Using `System.Type.IsDefined` can easily fix this issue.

Reference:
[Unity Issue Tracker - [IL2CPP] NotSupportedException is thrown when using System.Type.GetCustomAttributes(Type, bool)](https://issuetracker.unity3d.com/issues/il2cpp-notsupportedexception-is-thrown-when-using-system-dot-type-dot-getcustomattributes-type-bool)

[c# - How enumerate all classes with custom class attribute? - Stack Overflow](https://stackoverflow.com/a/14718945)